### PR TITLE
Fix SysBase

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -1,9 +1,11 @@
 
+#define __NOLIBBASE__
 #include <exec/types.h>
 #include <exec/execbase.h>
 #include <proto/exec.h>
 
-struct ExecBase* SysBase = NULL;
+// define a static, local SysBase to not to interfere with the regular SysBase symbol
+static struct ExecBase* SysBase = NULL;
 
 
 /**** OS/C/ASM WRAPPERS ******************************************************/


### PR DESCRIPTION
SysBase as a static is the correct way, otherwise an externally accessible symbol
will collide with any application-side SysBase symbol.
But in order to do that we need proto/exec.c to not declare the SysBase symbol
as extern. Do this by providing __NOLIBBASE__ before including the header.